### PR TITLE
direct links to /en/

### DIFF
--- a/_includes/cards/ojs2/learning-ojs-2.md
+++ b/_includes/cards/ojs2/learning-ojs-2.md
@@ -1,4 +1,4 @@
 
-### [Learning OJS 2.x](/learning-ojs-2/)
+### [Learning OJS 2.x](/learning-ojs-2/en/)
 
-A visual, step-by-step guide to managing a journal with Open Journal Systems 2.x. [View Now](/learning-ojs-2/)
+A visual, step-by-step guide to managing a journal with Open Journal Systems 2.x. [View Now](/learning-ojs-2/en/)

--- a/_includes/cards/ojs2/ojs-2-technical-reference.md
+++ b/_includes/cards/ojs2/ojs-2-technical-reference.md
@@ -1,4 +1,4 @@
 
-### [OJS 2.x Technical Reference](/ojs-2-technical-reference/)
+### [OJS 2.x Technical Reference](/ojs-2-technical-reference/en/)
 
-An extensive document regarding versions 2.x of the OJS platform. [View Now](/ojs-2-technical-reference/)
+An extensive document regarding versions 2.x of the OJS platform. [View Now](/ojs-2-technical-reference/en/)

--- a/_includes/cards/ojs3/crossref-ojs-manual.md
+++ b/_includes/cards/ojs3/crossref-ojs-manual.md
@@ -1,7 +1,7 @@
 
-### [Crossref and DOIs](./crossref-ojs-manual/)
+### [Crossref and DOIs](./crossref-ojs-manual/en/)
 
-Learn how you can take advantage of PKP's partnership with Crossref to help publishers and journals take advantage of Crossref's research indexing service. [View Now](./crossref-ojs-manual/)
+Learn how you can take advantage of PKP's partnership with Crossref to help publishers and journals take advantage of Crossref's research indexing service. [View Now](./crossref-ojs-manual/en/)
 
-- [DOI Plugin Guide](./doi-plugin/)
-- [Crossref Plugin Guide](./crossref-ojs-manual/)
+- [DOI Plugin Guide](./doi-plugin/en/)
+- [Crossref Plugin Guide](./crossref-ojs-manual/en/)

--- a/_includes/cards/ojs3/translating-guide.md
+++ b/_includes/cards/ojs3/translating-guide.md
@@ -1,7 +1,7 @@
 
-### [Interested in Translation?](./translating-guide/)
+### [Interested in Translation?](./translating-guide/en/)
 
 PKP is always looking for engaged community members to assist in translation of both software and documentation.
 
 - [Documentation Translation](https://github.com/pkp/documentation-interest-group)
-- [Software Translation Guide](./translating-guide/)
+- [Software Translation Guide](./translating-guide/en/)

--- a/_includes/cards/ojs3/using-paypal-for-ojs-and-ocs.md
+++ b/_includes/cards/ojs3/using-paypal-for-ojs-and-ocs.md
@@ -1,4 +1,4 @@
 
-### [Using Paypal for OJS](./using-paypal-for-ojs-and-ocs/)
+### [Using Paypal for OJS](./using-paypal-for-ojs-and-ocs/en/)
 
-OJS 3.1.x supports the use of the [PayPal online payment system](http://www.paypal.com) for secure online financial transactions. This document will outline the basic steps in getting this up and running. [View Now](./using-paypal-for-ojs-and-ocs/)
+OJS 3.1.x supports the use of the [PayPal online payment system](http://www.paypal.com) for secure online financial transactions. This document will outline the basic steps in getting this up and running. [View Now](./using-paypal-for-ojs-and-ocs/en/)


### PR DESCRIPTION
Docs without translations move to /en/ directly without landing on a selection page.